### PR TITLE
Integration tests for CorticalClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: python
-
 python:
 - '2.7'
 
 install:
-- pip install pytest
-- python setup.py install
+ - pip install pytest
+ - python setup.py install
 
 script:
-# Run integration tests locally since they require a Cortical.io API key
-- py.test --cov tests/unit/
+ # Run integration tests locally since they require a Cortical.io API key
+ - cd tests/unit/
+ - py.test --cov .
 
 after_success:
-- pip install python-coveralls
-- coveralls
+ - pip install python-coveralls
+ - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: python
+
 python:
 - '2.7'
 
 install:
- - pip install pytest
- - python setup.py install
+- pip install pytest
+- python setup.py install
 
 script:
- - py.test --cov cortipy
+# Run integration tests locally since they require a Cortical.io API key
+- py.test --cov tests/unit/
 
 after_success:
- - pip install python-coveralls
- - coveralls
+- pip install python-coveralls
+- coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 script:
  # Run integration tests locally since they require a Cortical.io API key
  - cd tests/unit/
- - py.test --cov .
+ - py.test --cov ../../cortipy .
 
 after_success:
  - pip install python-coveralls

--- a/tests/integration/compare_test.py
+++ b/tests/integration/compare_test.py
@@ -1,0 +1,63 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Numenta, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+  This test verifies that compare correctly does the call to Cortical.io's
+  API and gets a dictionary of distances
+"""
+
+import cortipy
+
+import unittest2 as unittest
+
+class CompareTest(unittest.TestCase):
+  """Requires CORTICAL_API_KEY to be set"""
+
+  def testCompare(self):
+    """
+    Tests client.createClassification(). Asserts the returned object has fields
+    with expected values for both the classifciation name and bitmap.
+    """
+    client = cortipy.CorticalClient(useCache=False)
+    bitmap1 = client.getBitmap("one")["fingerprint"]["positions"]
+    bitmap2 = client.getBitmap("two")["fingerprint"]["positions"]
+
+    distances = client.compare(bitmap1, bitmap2)
+
+    types = ["cosineSimilarity", "euclideanDistance", "jaccardDistance",
+        "overlappingAll", "overlappingLeftRight", "overlappingRightLeft",
+        "sizeLeft", "sizeRight", "weightedScoring"]
+
+    self.assertIsInstance(distances, dict,
+        "The returned object is not a dictionary")
+
+    for t in types:
+      self.assertIn(t, distances,
+          "No \'{}\' field in the distances".format(t))
+
+    for t in types:
+      self.assertIsInstance(distances[t], (float, int),
+          "No \'{}\' field in the distances".format(t))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/integration/compare_test.py
+++ b/tests/integration/compare_test.py
@@ -26,8 +26,9 @@
 """
 
 import cortipy
+import unittest
 
-import unittest2 as unittest
+
 
 class CompareTest(unittest.TestCase):
   """Requires CORTICAL_API_KEY to be set"""
@@ -57,6 +58,7 @@ class CompareTest(unittest.TestCase):
     for t in types:
       self.assertIsInstance(distances[t], (float, int),
           "No \'{}\' field in the distances".format(t))
+
 
 
 if __name__ == '__main__':

--- a/tests/integration/create_classification_test.py
+++ b/tests/integration/create_classification_test.py
@@ -21,13 +21,14 @@
 # THE SOFTWARE.
 
 """
-  This test verifies that createClassification correctly does the call to Cortical.io's
-  API and returns a bitmap
+  This test verifies that createClassification correctly does the call to
+  Cortical.io's API and returns a bitmap
 """
 
 import cortipy
+import unittest
 
-import unittest2 as unittest
+
 
 class CreateClassificationTest(unittest.TestCase):
   """Requires CORTICAL_API_KEY to be set"""
@@ -52,6 +53,7 @@ class CreateClassificationTest(unittest.TestCase):
 
     self._checkValidResponse(response, name)
 
+
   def testCreateClassificationOnlyPositives(self):
     """
     Tests client.createClassification(). Asserts the returned object has fields
@@ -71,6 +73,7 @@ class CreateClassificationTest(unittest.TestCase):
 
     self._checkValidResponse(response, name)
   
+
   def _checkValidResponse(self, response, name):
     # Assert: check the result object.
     self.assertIn("positions", response,
@@ -82,6 +85,7 @@ class CreateClassificationTest(unittest.TestCase):
       "The returned category name is incorrect.")
     self.assertIsInstance(response["positions"], list,
       "The returned object does not contain a \'positions\' list.")
+
 
 
 if __name__ == '__main__':

--- a/tests/integration/create_classification_test.py
+++ b/tests/integration/create_classification_test.py
@@ -1,0 +1,88 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Numenta, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+  This test verifies that createClassification correctly does the call to Cortical.io's
+  API and returns a bitmap
+"""
+
+import cortipy
+
+import unittest2 as unittest
+
+class CreateClassificationTest(unittest.TestCase):
+  """Requires CORTICAL_API_KEY to be set"""
+
+  def testCreateClassification(self):
+    """
+    Tests client.createClassification(). Asserts the returned object has fields
+    with expected values for both the classifciation name and bitmap.
+    """
+    client = cortipy.CorticalClient(useCache=False)
+
+    name = "programming languages"
+    positives = [
+      "Always code as if the guy who ends up maintaining your code will be a \
+      violent psychopath who knows where you live.",
+      "To iterate is human, to recurse divine.",
+      "First learn computer science and all the theory. Next develop a \
+      programming style. Then forget all that and just hack." ]
+    negatives = ["To err is human, to forgive divine."]
+
+    response = client.createClassification(name, positives, negatives)
+
+    self._checkValidResponse(response, name)
+
+  def testCreateClassificationOnlyPositives(self):
+    """
+    Tests client.createClassification(). Asserts the returned object has fields
+    with expected values for both the classifciation name and bitmap.
+    """
+    client = cortipy.CorticalClient(useCache=False)
+
+    name = "programming languages"
+    positives = [
+      "Always code as if the guy who ends up maintaining your code will be a \
+      violent psychopath who knows where you live.",
+      "To iterate is human, to recurse divine.",
+      "First learn computer science and all the theory. Next develop a \
+      programming style. Then forget all that and just hack." ]
+
+    response = client.createClassification(name, positives)
+
+    self._checkValidResponse(response, name)
+  
+  def _checkValidResponse(self, response, name):
+    # Assert: check the result object.
+    self.assertIn("positions", response,
+      "No \'positions\' field in the returned object.")
+    self.assertIn("categoryName", response,
+      "No \'categoryName\' field in the returned object.")
+
+    self.assertEqual(response["categoryName"], name,
+      "The returned category name is incorrect.")
+    self.assertIsInstance(response["positions"], list,
+      "The returned object does not contain a \'positions\' list.")
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/integration/create_classification_test.py
+++ b/tests/integration/create_classification_test.py
@@ -77,14 +77,14 @@ class CreateClassificationTest(unittest.TestCase):
   def _checkValidResponse(self, response, name):
     # Assert: check the result object.
     self.assertIn("positions", response,
-      "No \'positions\' field in the returned object.")
+        "No \'positions\' field in the returned object.")
     self.assertIn("categoryName", response,
-      "No \'categoryName\' field in the returned object.")
+        "No \'categoryName\' field in the returned object.")
 
     self.assertEqual(response["categoryName"], name,
-      "The returned category name is incorrect.")
+        "The returned category name is incorrect.")
     self.assertIsInstance(response["positions"], list,
-      "The returned object does not contain a \'positions\' list.")
+        "The returned object does not contain a \'positions\' list.")
 
 
 

--- a/tests/integration/get_bitmap_test.py
+++ b/tests/integration/get_bitmap_test.py
@@ -26,8 +26,9 @@
 """
 
 import cortipy
+import unittest
 
-import unittest2 as unittest
+
 
 class GetBitmapTest(unittest.TestCase):
   """Requires CORTICAL_API_KEY to be set"""
@@ -37,17 +38,20 @@ class GetBitmapTest(unittest.TestCase):
     bitmap = client.getBitmap("computer")
 
     self._checkValidBitmap(bitmap, "computer")
+
     
   def testMultipleTokens(self):
     client = cortipy.CorticalClient(useCache=False)
     with self.assertRaises(ValueError):
       client.getBitmap("this should use getTextBitmap")
+      
 
   def testNoFPFromAPI(self):
     client = cortipy.CorticalClient(useCache=False)
     bitmap = client.getBitmap("thisisnotarealword.")
 
     self._checkValidBitmap(bitmap, "thisisnotarealword.")
+
 
   def _checkValidBitmap(self, bitmap, term):
     self.assertIsInstance(bitmap, dict,
@@ -64,6 +68,7 @@ class GetBitmapTest(unittest.TestCase):
     self.assertIsInstance(bitmap["fingerprint"]["positions"], list,
       "The returned object does not contain a \'positions\' list within its "
       " \'fingerprint\' dictionary.")
+
 
 
 if __name__ == '__main__':

--- a/tests/integration/get_bitmap_test.py
+++ b/tests/integration/get_bitmap_test.py
@@ -1,0 +1,70 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Numenta, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+  This test verifies that getBitmap correctly does the call to Cortical.io's
+  API and returns a bitmap
+"""
+
+import cortipy
+
+import unittest2 as unittest
+
+class GetBitmapTest(unittest.TestCase):
+  """Requires CORTICAL_API_KEY to be set"""
+
+  def testValidResponse(self):
+    client = cortipy.CorticalClient(useCache=False)
+    bitmap = client.getBitmap("computer")
+
+    self._checkValidBitmap(bitmap, "computer")
+    
+  def testMultipleTokens(self):
+    client = cortipy.CorticalClient(useCache=False)
+    with self.assertRaises(ValueError):
+      client.getBitmap("this should use getTextBitmap")
+
+  def testNoFPFromAPI(self):
+    client = cortipy.CorticalClient(useCache=False)
+    bitmap = client.getBitmap("thisisnotarealword.")
+
+    self._checkValidBitmap(bitmap, "thisisnotarealword.")
+
+  def _checkValidBitmap(self, bitmap, term):
+    self.assertIsInstance(bitmap, dict,
+        "The returned object is not a dictionary")
+    self.assertIn("term", bitmap,
+      "No \'term\' field in the returned object.")
+    self.assertEqual(bitmap["term"], term,
+      "The returned term is incorrect.")
+    self.assertIsInstance(bitmap["fingerprint"], dict,
+      "The returned object does not contain a \'fingerprint'\ dictionary.")
+    self.assertIn("positions", bitmap["fingerprint"],
+      "The returned object does not contain a \'positions\' field for the "
+      "\'fingerprint\'.")
+    self.assertIsInstance(bitmap["fingerprint"]["positions"], list,
+      "The returned object does not contain a \'positions\' list within its "
+      " \'fingerprint\' dictionary.")
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/integration/get_bitmap_test.py
+++ b/tests/integration/get_bitmap_test.py
@@ -57,17 +57,17 @@ class GetBitmapTest(unittest.TestCase):
     self.assertIsInstance(bitmap, dict,
         "The returned object is not a dictionary")
     self.assertIn("term", bitmap,
-      "No \'term\' field in the returned object.")
+        "No \'term\' field in the returned object.")
     self.assertEqual(bitmap["term"], term,
-      "The returned term is incorrect.")
+        "The returned term is incorrect.")
     self.assertIsInstance(bitmap["fingerprint"], dict,
-      "The returned object does not contain a \'fingerprint'\ dictionary.")
+        "The returned object does not contain a \'fingerprint'\ dictionary.")
     self.assertIn("positions", bitmap["fingerprint"],
-      "The returned object does not contain a \'positions\' field for the "
-      "\'fingerprint\'.")
+        "The returned object does not contain a \'positions\' field for the "
+        "\'fingerprint\'.")
     self.assertIsInstance(bitmap["fingerprint"]["positions"], list,
-      "The returned object does not contain a \'positions\' list within its "
-      " \'fingerprint\' dictionary.")
+        "The returned object does not contain a \'positions\' list within its "
+        " \'fingerprint\' dictionary.")
 
 
 

--- a/tests/integration/get_context_test.py
+++ b/tests/integration/get_context_test.py
@@ -49,28 +49,28 @@ class GetContextTest(unittest.TestCase):
   def _checkValidContexts(self, contexts):
     # Assert: check the result object.
     self.assertIsInstance(contexts, list,
-      "Returned object is not of type list as expected.")
+        "Returned object is not of type list as expected.")
     self.assertGreaterEqual(len(contexts), 1,
-      "Returned object did not contain any elements")
+        "Returned object did not contain any elements")
     self.assertIsInstance(contexts[0], dict)
     self.assertIn("context_label", contexts[0],
-      "Context does not contain \'context_label\'")
+        "Context does not contain \'context_label\'")
     self.assertIn("fingerprint", contexts[0],
-      "Context does not contain \'fingerprint\'")
+        "Context does not contain \'fingerprint\'")
     self.assertIn("context_id", contexts[0],
-      "Context does not contain \'context_id\'")
+        "Context does not contain \'context_id\'")
     self.assertIsInstance(contexts[0]["context_label"], str,
-      "The \'context_label\' field is not of type string.")
+        "The \'context_label\' field is not of type string.")
     self.assertEqual(contexts[0]["context_id"], 0,
-      "The top context does not have ID of zero.")
+        "The top context does not have ID of zero.")
     self.assertIsInstance(contexts[0]["fingerprint"], dict,
-      "The \'context_label\' field is not of type string.")
+        "The \'context_label\' field is not of type string.")
     self.assertIn("positions", contexts[0]["fingerprint"],
-      "The returned object does not contain a \'positions\' field for the "
-      "\'fingerprint\'.")
+        "The returned object does not contain a \'positions\' field for the "
+        "\'fingerprint\'.")
     self.assertIsInstance(contexts[0]["fingerprint"]["positions"], list,
-      "The returned object does not contain a \'positions\' list within its "
-      " \'fingerprint\' dictionary.")
+        "The returned object does not contain a \'positions\' list within its "
+        " \'fingerprint\' dictionary.")
 
 
 

--- a/tests/integration/get_context_test.py
+++ b/tests/integration/get_context_test.py
@@ -26,11 +26,13 @@
 """
 
 import cortipy
+import unittest
 
-import unittest2 as unittest
+
 
 class GetContextTest(unittest.TestCase):
   """Requires CORTICAL_API_KEY to be set"""
+
   def testGetContext(self):
     """
     Tests client.getContext() for a sample term.
@@ -42,16 +44,21 @@ class GetContextTest(unittest.TestCase):
 
     contexts = client.getContext("android")
     self._checkValidContexts(contexts)
+
     
   def _checkValidContexts(self, contexts):
     # Assert: check the result object.
     self.assertIsInstance(contexts, list,
       "Returned object is not of type list as expected.")
-    self.assertGreaterEqual(len(contexts), 1, "Returned object did not contain any elements")
+    self.assertGreaterEqual(len(contexts), 1,
+      "Returned object did not contain any elements")
     self.assertIsInstance(contexts[0], dict)
-    self.assertIn("context_label", contexts[0], "Context does not contain \'context_label\'")
-    self.assertIn("fingerprint", contexts[0], "Context does not contain \'fingerprint\'")
-    self.assertIn("context_id", contexts[0], "Context does not contain \'context_id\'")
+    self.assertIn("context_label", contexts[0],
+      "Context does not contain \'context_label\'")
+    self.assertIn("fingerprint", contexts[0],
+      "Context does not contain \'fingerprint\'")
+    self.assertIn("context_id", contexts[0],
+      "Context does not contain \'context_id\'")
     self.assertIsInstance(contexts[0]["context_label"], str,
       "The \'context_label\' field is not of type string.")
     self.assertEqual(contexts[0]["context_id"], 0,
@@ -64,6 +71,7 @@ class GetContextTest(unittest.TestCase):
     self.assertIsInstance(contexts[0]["fingerprint"]["positions"], list,
       "The returned object does not contain a \'positions\' list within its "
       " \'fingerprint\' dictionary.")
+
 
 
 if __name__ == '__main__':

--- a/tests/integration/get_context_test.py
+++ b/tests/integration/get_context_test.py
@@ -1,0 +1,70 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Numenta, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+  This test verifies that getContext correctly does the call to Cortical.io's
+  API and gets a list of contexts
+"""
+
+import cortipy
+
+import unittest2 as unittest
+
+class GetContextTest(unittest.TestCase):
+  """Requires CORTICAL_API_KEY to be set"""
+  def testGetContext(self):
+    """
+    Tests client.getContext() for a sample term.
+    Asserts the returned object contains the correct fields and have contents as
+    expected.
+    """
+    # Act: create the client object we'll be testing.
+    client = cortipy.CorticalClient(useCache=False)
+
+    contexts = client.getContext("android")
+    self._checkValidContexts(contexts)
+    
+  def _checkValidContexts(self, contexts):
+    # Assert: check the result object.
+    self.assertIsInstance(contexts, list,
+      "Returned object is not of type list as expected.")
+    self.assertGreaterEqual(len(contexts), 1, "Returned object did not contain any elements")
+    self.assertIsInstance(contexts[0], dict)
+    self.assertIn("context_label", contexts[0], "Context does not contain \'context_label\'")
+    self.assertIn("fingerprint", contexts[0], "Context does not contain \'fingerprint\'")
+    self.assertIn("context_id", contexts[0], "Context does not contain \'context_id\'")
+    self.assertIsInstance(contexts[0]["context_label"], str,
+      "The \'context_label\' field is not of type string.")
+    self.assertEqual(contexts[0]["context_id"], 0,
+      "The top context does not have ID of zero.")
+    self.assertIsInstance(contexts[0]["fingerprint"], dict,
+      "The \'context_label\' field is not of type string.")
+    self.assertIn("positions", contexts[0]["fingerprint"],
+      "The returned object does not contain a \'positions\' field for the "
+      "\'fingerprint\'.")
+    self.assertIsInstance(contexts[0]["fingerprint"]["positions"], list,
+      "The returned object does not contain a \'positions\' list within its "
+      " \'fingerprint\' dictionary.")
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/integration/get_text_bitmap_test.py
+++ b/tests/integration/get_text_bitmap_test.py
@@ -26,8 +26,9 @@
 """
 
 import cortipy
+import unittest
 
-import unittest2 as unittest
+
 
 class GetTextBitmapTest(unittest.TestCase):
   """Requires CORTICAL_API_KEY to be set"""
@@ -37,6 +38,7 @@ class GetTextBitmapTest(unittest.TestCase):
     bitmap = client.getTextBitmap("this is a longer string")
 
     self._checkValidBitmap(bitmap, "this is a longer string")
+
 
   def _checkValidBitmap(self, bitmap, text):
     self.assertIsInstance(bitmap, dict,
@@ -53,6 +55,7 @@ class GetTextBitmapTest(unittest.TestCase):
     self.assertIsInstance(bitmap["fingerprint"]["positions"], list,
       "The returned object does not contain a \'positions\' list within its "
       " \'fingerprint\' dictionary.")
+
 
 
 if __name__ == '__main__':

--- a/tests/integration/get_text_bitmap_test.py
+++ b/tests/integration/get_text_bitmap_test.py
@@ -44,17 +44,17 @@ class GetTextBitmapTest(unittest.TestCase):
     self.assertIsInstance(bitmap, dict,
         "The returned object is not a dictionary")
     self.assertIn("text", bitmap,
-      "No \'term\' field in the returned object.")
+        "No \'term\' field in the returned object.")
     self.assertEqual(bitmap["text"], text,
-      "The returned term is incorrect.")
+        "The returned term is incorrect.")
     self.assertIsInstance(bitmap["fingerprint"], dict,
-      "The returned object does not contain a \'fingerprint'\ dictionary.")
+        "The returned object does not contain a \'fingerprint'\ dictionary.")
     self.assertIn("positions", bitmap["fingerprint"],
-      "The returned object does not contain a \'positions\' field for the "
-      "\'fingerprint\'.")
+        "The returned object does not contain a \'positions\' field for the "
+        "\'fingerprint\'.")
     self.assertIsInstance(bitmap["fingerprint"]["positions"], list,
-      "The returned object does not contain a \'positions\' list within its "
-      " \'fingerprint\' dictionary.")
+        "The returned object does not contain a \'positions\' list within its "
+        " \'fingerprint\' dictionary.")
 
 
 

--- a/tests/integration/get_text_bitmap_test.py
+++ b/tests/integration/get_text_bitmap_test.py
@@ -1,0 +1,59 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015 Numenta, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+  This test verifies that getTextBitmap correctly does the call to Cortical.io's
+  API and returns a bitmap
+"""
+
+import cortipy
+
+import unittest2 as unittest
+
+class GetTextBitmapTest(unittest.TestCase):
+  """Requires CORTICAL_API_KEY to be set"""
+
+  def testValidResponse(self):
+    client = cortipy.CorticalClient(useCache=False)
+    bitmap = client.getTextBitmap("this is a longer string")
+
+    self._checkValidBitmap(bitmap, "this is a longer string")
+
+  def _checkValidBitmap(self, bitmap, text):
+    self.assertIsInstance(bitmap, dict,
+        "The returned object is not a dictionary")
+    self.assertIn("text", bitmap,
+      "No \'term\' field in the returned object.")
+    self.assertEqual(bitmap["text"], text,
+      "The returned term is incorrect.")
+    self.assertIsInstance(bitmap["fingerprint"], dict,
+      "The returned object does not contain a \'fingerprint'\ dictionary.")
+    self.assertIn("positions", bitmap["fingerprint"],
+      "The returned object does not contain a \'positions\' field for the "
+      "\'fingerprint\'.")
+    self.assertIsInstance(bitmap["fingerprint"]["positions"], list,
+      "The returned object does not contain a \'positions\' list within its "
+      " \'fingerprint\' dictionary.")
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Added integration tests that can be run locally and updated travis to ignore the integration tests because PRs and forks will not have access to the CORTICAL_API_KEY.

@BoltzmannBrain 
