### PR TITLE
Refactor caching, including use of msgpack for serialization

### DIFF
--- a/cortipy/cortical_client.py
+++ b/cortipy/cortical_client.py
@@ -94,8 +94,21 @@ class CorticalClient():
 
 
   def _cachedRequest(self, fn, url, params, headers, data=None):
+    """
+    Issues Cortical.io API requests, utilizing local filesystem cache if client
+    was created with useCache=True.
+
+    @param  fn      (function)  e.g. requests.Session().post or
+                                requests.Session().get
+    @param  url     (str)       URL argument to fn
+    @param  params  (dict)      params argument to fn
+    @param  headers (dict)      headers argument to fn
+    @param  data    (str)       Optional data argument to fn
+    @return         (obj)       Parsed response from Cortical.io API.
+    """
+
     def _doRequest():
-      # Internal request wrapper to
+      # Internal request wrapper to issue request and handle the errors.
       extras = {}
       if data:
         extras["data"] = data
@@ -160,15 +173,15 @@ class CorticalClient():
 
     if method == 'GET':
       response = self._cachedRequest(self._session.get,
-                                      url,
-                                      params=queryParams,
-                                      headers=headers)
+                                     url,
+                                     params=queryParams,
+                                     headers=headers)
     elif method == 'POST':
       response = self._cachedRequest(self._session.post,
-                                      url,
-                                      params=queryParams,
-                                      headers=headers,
-                                      data=postData)
+                                     url,
+                                     params=queryParams,
+                                     headers=headers,
+                                     data=postData)
     else:
       raise RequestMethodError("Method " + method + " is not recognized.")
 

--- a/cortipy/cortical_client.py
+++ b/cortipy/cortical_client.py
@@ -138,6 +138,7 @@ class CorticalClient():
     self.verbosity = verbosity
     self.retina = retina
     self.useCache = useCache
+    self._session = requests.Session()
 
 
   @cacheDecorator
@@ -157,9 +158,9 @@ class CorticalClient():
         print "\tPost data: \n\t%s" % postData
 
     if method == 'GET':
-      response = requests.get(url, params=queryParams, headers=headers)
+      response = self._session.get(url, params=queryParams, headers=headers)
     elif method == 'POST':
-      response = requests.post(
+      response = self._session.post(
         url, params=queryParams, headers=headers, data=postData)
     else:
       raise RequestMethodError("Method " + method + " is not recognized.")

--- a/cortipy/cortical_client.py
+++ b/cortipy/cortical_client.py
@@ -26,13 +26,12 @@ import random
 import requests
 
 from cortipy.exceptions import UnsuccessfulEncodingError, RequestMethodError
-from functools import wraps
 
 try:
   import simplejson as json
 except ImportError:
   import json
-
+import msgpack
 
 DEFAULT_BASE_URL = "http://api.cortical.io/rest"
 DEFAULT_RETINA = "en_synonymous"
@@ -60,56 +59,6 @@ RETINA_SIZES = {
 TERM_SPARSITY = 0.01
 
 
-def cacheDecorator(func):
-  """
-  Created to wrap the CorticalClient's _queryAPI() method. If the client's
-  cache is enabled, will try to load API responses from the local cache before
-  going to the API. Then before returning control to the calling function, will
-  cache the API responses into the local file system.
-  """
-  @wraps(func)
-  def cacheWrapper(*args, **kwargs):
-    client = args[0]
-    cacheDir = client.cacheDir
-    method = args[1]
-    resourcePath = args[2]
-    queryParams = args[3]
-    postData = ""
-    if "postData" in kwargs:
-      postData = kwargs["postData"]
-    requestString = json.dumps([
-      resourcePath, method, json.dumps(queryParams), postData
-    ])
-    cacheKey = hashlib.sha224(requestString).hexdigest()
-    cachePath = os.path.join(cacheDir, cacheKey + ".json")
-
-    if client.useCache and os.path.exists(cachePath):
-      if client.verbosity > 0:
-        print "Fetching API data from the cache at %s" % cachePath
-        print "\tRequest string: %s" % requestString
-      return json.loads(open(cachePath, "r").read())
-
-    else:
-      # Wrapped function gets executed here.
-      result = func(*args, **kwargs)
-
-      if client.useCache:
-        # Lazily create cache directory.
-        if not os.path.exists(client.cacheDir):
-          if client.verbosity > 0:
-            print "Creating cache at %s" % client.cacheDir
-          os.makedirs(client.cacheDir)
-        if client.verbosity > 0:
-          print "Writing API response to the cache at %s" % cachePath
-          print "\t%s" % result
-        with open(cachePath, "w") as f:
-          f.write(json.dumps(result))
-
-      return result
-
-  return cacheWrapper
-
-
 
 class CorticalClient():
   """
@@ -134,14 +83,66 @@ class CorticalClient():
     else:
       self.apiUrl = baseUrl
 
+    if useCache and not os.path.exists(cacheDir):
+      os.makedirs(cacheDir)
+
+    self.useCache = useCache
     self.cacheDir = cacheDir
     self.verbosity = verbosity
     self.retina = retina
-    self.useCache = useCache
     self._session = requests.Session()
 
 
-  @cacheDecorator
+  def _cachedRequest(self, fn, url, params, headers, data=None):
+    def _doRequest():
+      # Internal request wrapper to
+      extras = {}
+      if data:
+        extras["data"] = data
+
+      response = fn(url, params=params, headers=headers, **extras)
+
+      if response.status_code != 200:
+        raise UnsuccessfulEncodingError(
+          "Response " + str(response.status_code) + ": " + response.content)
+
+      try:
+        responseObj = json.loads(response.content)
+      except ValueError("Could not decode the query response."):
+        responseObj = []
+
+      return responseObj
+
+    if not self.useCache:
+      return _doRequest()
+
+    # Construct deterministic hash for request
+
+    m = hashlib.sha224()
+
+    m.update(fn.__name__)
+    m.update(url)
+    m.update("".join(str(y) for x in sorted(headers.iteritems()) for y in x))
+    m.update("".join(str(y) for x in sorted(params.iteritems()) for y in x))
+
+    if data:
+      m.update(data)
+
+    cacheKey = m.hexdigest()
+
+    cachePath = os.path.join(self.cacheDir, "{}.msgpack".format(cacheKey))
+
+    if os.path.isfile(cachePath):
+      # Request has been made before, load and return original response
+      response = msgpack.load(open(cachePath, "r"))
+    else:
+      # Make new request, cache the response
+      response = _doRequest()
+      msgpack.dump(response, open(cachePath, "w"))
+
+    return response
+
+
   def _queryAPI(self, method, resourcePath, queryParams,
                 postData=None, headers=None):
     url = self.apiUrl + resourcePath
@@ -158,24 +159,20 @@ class CorticalClient():
         print "\tPost data: \n\t%s" % postData
 
     if method == 'GET':
-      response = self._session.get(url, params=queryParams, headers=headers)
+      response = self._cachedRequest(self._session.get,
+                                      url,
+                                      params=queryParams,
+                                      headers=headers)
     elif method == 'POST':
-      response = self._session.post(
-        url, params=queryParams, headers=headers, data=postData)
+      response = self._cachedRequest(self._session.post,
+                                      url,
+                                      params=queryParams,
+                                      headers=headers,
+                                      data=postData)
     else:
       raise RequestMethodError("Method " + method + " is not recognized.")
-    if response.status_code != 200:
-      raise UnsuccessfulEncodingError(
-        "Response " + str(response.status_code) + ": " + response.content)
-    if self.verbosity > 1:
-      print "API Response content:"
-      print response.content
-    try:
-      responseObj = json.loads(response.content)
-    except ValueError("Could not decode the query response."):
-      responseObj = []
-    return responseObj
 
+    return response
 
   def _placeholderFingerprint(self, text, option=random):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sure==1.2.10
 # Program requirements
 requests==1.2.3
 simplejson
+msgpack-python

--- a/tests/unit/client_cache_test.py
+++ b/tests/unit/client_cache_test.py
@@ -21,12 +21,14 @@
 # THE SOFTWARE.
 
 import cortipy
-import hashlib
 import httpretty
 import os
+import requests
+import shutil
+import tempfile
 import unittest2 as unittest
 
-from mock import patch, mock_open
+from mock import Mock, patch
 
 try:
   import simplejson as json
@@ -49,258 +51,69 @@ def getMockApiData(name):
 class CorticalClientTestCase(unittest.TestCase):
 
 
-  @patch.object(os, 'makedirs')
-  def testConstructionDoesNotTouchFileSystem(self, mockMkdirs):
-    cortipy.CorticalClient(apiKey="fakeKey")
-    assert(mockMkdirs.call_count == 0)
-
-
   @httpretty.activate
-  @patch.object(os.path, 'exists', return_value=False)
-  @patch.object(os, 'makedirs')
-  def testUsingCache_CacheDirIsLazilyCreated(self,
-                                                  mockMkDirs, 
-                                                  _mockPathExists):
-    """
-    When using cache, a cache directory is created on the first call to query 
-    the API if it does not exist.
-    """
-    # Arrange.
-    mockOpen = mock_open()
-    httpretty.register_uri(httpretty.GET,
-                           "http://api.cortical.io/rest/mockResourcePath",
-                           body='{"dummy":"mock body"}',
-                           status=200,
-                           content_type="application/json")
-    resourcePath = "/mockResourcePath"
-    method = "GET"
-    queryParams = "mock queryParams"
-    postData = "mock postData"
-
-    # Patching file open
-    with patch('__builtin__.open', mockOpen, create=True):
-      # Act.
-      client = cortipy.CorticalClient(apiKey="fakeKey", useCache=True)
-      client._queryAPI(method, resourcePath, queryParams, postData=postData)
-
-    # Assert.
-    mockMkDirs.assert_called_once_with("/tmp/cortipy")
-
-
-  @httpretty.activate
-  @patch.object(os.path, 'exists', return_value=False)
-  @patch.object(os, 'makedirs')
-  def testNotUsingCache_CacheDirIsNotCreated(self,
-                                                  mockMkDirs, 
-                                                  _mockPathExists):
-    """
-    When using not using the cache, a cache directory is not created when
-    querying the API.
-    """
-    # Arrange.
-    mockOpen = mock_open()
-    httpretty.register_uri(httpretty.GET,
-                           "http://api.cortical.io/rest/mockResourcePath",
-                           body='{"dummy":"mock body"}',
-                           status=200,
-                           content_type="application/json")
-    resourcePath = "/mockResourcePath"
-    method = "GET"
-    queryParams = "mock queryParams"
-    postData = "mock postData"
-  
-    # Patching file open
-    with patch('__builtin__.open', mockOpen, create=False):
-      # Act.
-      client = cortipy.CorticalClient(apiKey="fakeKey", useCache=False)
-      client._queryAPI(method, resourcePath, queryParams, postData=postData)
-  
-    # Assert.
-    assert(mockMkDirs.call_count == 0)
-  
-  
-  @httpretty.activate
-  @patch.object(os.path, 'exists', return_value=False)
-  def testUsingCache_ApiGetCallsWriteToCache(self, mockPathExists):
-    """
-    When using the cache, GET API response is written to the cache directory in
-    a new JSON file, using a cache key created by the hashed request string.
-    """
-    # Arrange.
-    mockOpen = mock_open()
-    httpretty.register_uri(httpretty.GET,
-                           "http://api.cortical.io/rest/mockResourcePath",
-                           body='{"dummy":"mock body"}',
-                           status=200,
-                           content_type="application/json")
-    resourcePath = "/mockResourcePath"
-    method = "GET"
-    queryParams = '{"get_fingerprint": true, \
-                    "retina_name": "en_synonymous", \
-                    "max_results": 10, \
-                    "term": "cat", \
-                    "start_index": 0}'
-    postData = None
-    
-    # os.path.exists() will be called twice. First to see if the cache path to
-    # the resource being fetched exists (we'll return False), and the 2nd time
-    # after the API call to decide whether to lazily create the cache directory.
-    # To this call we'll return True so it doesn't try to create it.
-    def existsSideEffect(arg):
-      if arg == "/tmp/cortipy":
-        return True
-  
-    mockPathExists.side_effect = existsSideEffect 
-    # Patching file open
-    with patch('__builtin__.open', mockOpen, create=True):
-      # Act.
-      client = cortipy.CorticalClient(apiKey="fakeKey", useCache=True)
-      client._queryAPI(method, resourcePath, queryParams, postData=postData)
-    expectedCacheString = hashlib.sha224(json.dumps([
-      resourcePath, method, json.dumps(queryParams), postData
-    ])).hexdigest()
-    expectedCachePath = "/tmp/cortipy/" + expectedCacheString + ".json"
-    
-    # Assert.
-    mockOpen.assert_called_once_with(expectedCachePath, "w")
-    handle = mockOpen()
-    handle.write.assert_called_once_with('{"dummy": "mock body"}')
-  
-
-  @httpretty.activate
-  @patch.object(os.path, 'exists', return_value=False)
-  def testUsingCache_ApiPostCallsWriteToCache(self, mockPathExists):
-    """
-    When using the cache, POST API response is written to the cache directory in
-    a new JSON file, using a cache key created by the hashed request string.
-    """
-    # Arrange.
-    mockOpen = mock_open()
-    httpretty.register_uri(httpretty.POST,
-                           "http://api.cortical.io/rest/mockResourcePath",
-                           body='{"dummy":"mock body"}',
-                           status=200,
-                           content_type="application/json")
-    resourcePath = "/mockResourcePath"
-    method = "POST"
-    queryParams = '{"get_fingerprint": true, \
-                    "retina_name": "en_synonymous", \
-                    "max_results": 10, \
-                    "term": "cat", \
-                    "start_index": 0}'
-    postData = "dummy post data"
-    
-    # os.path.exists() will be called twice. First to see if the cache path to
-    # the resource being fetched exists (we'll return False), and the 2nd time
-    # after the API call to decide whether to lazily create the cache directory.
-    # To this call we'll return True so it doesn't try to create it.
-    def existsSideEffect(arg):
-      if arg == "/tmp/cortipy":
-        return True
-  
-    mockPathExists.side_effect = existsSideEffect 
-    # Patching file open
-    with patch('__builtin__.open', mockOpen, create=True):
-      # Act.
-      client = cortipy.CorticalClient(apiKey="fakeKey", useCache=True)
-      client._queryAPI(method, resourcePath, queryParams, postData=postData)
-    
-    expectedCacheString = hashlib.sha224(json.dumps([
-      resourcePath, method, json.dumps(queryParams), postData
-    ])).hexdigest()
-    expectedCachePath = "/tmp/cortipy/" + expectedCacheString + ".json"
-    
-    # Assert.
-    mockOpen.assert_called_once_with(expectedCachePath, "w")
-    handle = mockOpen()
-    handle.write.assert_called_once_with('{"dummy": "mock body"}')
-  
-
-  @httpretty.activate
-  @patch.object(os.path, 'exists', return_value=False)
-  def testNotUsingCache_ApiCallsDontWriteToCache(self, mockExists):
+  @patch.object(requests.sessions.Session, "get")
+  def testNotUsingCache_ApiCallsDontReadFromCache(self, mockGet):
     """
     When not using the cache, API calls do not write responses to the cache.
     """
-    # Arrange.
-    mockOpen = mock_open()
-    httpretty.register_uri(httpretty.GET,
-                           "http://api.cortical.io/rest/mockResourcePath",
-                           body='{"dummy":"mock body"}',
-                           status=200,
-                           content_type="application/json")
+    mockGet.__name__ = "get"
+    mockGet.return_value = Mock(status_code=200,
+                                content='{"dummy": "mock body"}')
+
     resourcePath = "/mockResourcePath"
     method = "GET"
-    queryParams = "mock queryParams"
+    queryParams = {}
     postData = "mock postData"
-  
-    # Patching file open
-    with patch('__builtin__.open', mockOpen, create=True):
-      # Act.
-      client = cortipy.CorticalClient(apiKey="fakeKey", useCache=False)
-      client._queryAPI(method, resourcePath, queryParams, postData=postData)
-    
-    # Assert.
-    self.assertEqual(0, mockOpen.call_count,
-      "Caching was attempted when useCache=False.")
-  
-  
-  @patch.object(os.path, 'exists', return_value=True)
-  def testUsingCache_ApiCallsReadFromCache(self, _mockExists):
+
+    cacheDir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, cacheDir)
+
+    # Act.  Make two identical calls.
+    client = cortipy.CorticalClient(apiKey="fakeKey", useCache=False)
+    result1 = client._queryAPI(
+      method, resourcePath, queryParams, postData=postData)
+    result2 = client._queryAPI(
+      method, resourcePath, queryParams, postData=postData)
+
+    # Assert.  Assert only one request made, both responses equal
+    self.assertEqual(mockGet.call_count, 2)
+    self.assertDictEqual(result1, result2)
+
+
+  @patch.object(requests.sessions.Session, "get")
+  def testUsingCache_ApiCallsReadFromCache(self, mockGet):
     """
-    When using the cache, API calls that are already cached are read from the 
+    When using the cache, API calls that are already cached are read from the
     cache instead of making a new API call.
     """
     # Arrange.
-    mockOpen = mock_open(read_data='{"dummy": "mock body"}')
-  
+    #mockOpen = mock_open(read_data='{"dummy": "mock body"}')
+
+    mockGet.__name__ = "get"
+    mockGet.return_value = Mock(status_code=200,
+                                content='{"dummy": "mock body"}')
+
     resourcePath = "/mockResourcePath"
     method = "GET"
-    queryParams = "mock queryParams"
+    queryParams = {}
     postData = "mock postData"
-  
-    # Patching file open
-    with patch('__builtin__.open', mockOpen, create=True):
-      # Act.
-      client = cortipy.CorticalClient(apiKey="fakeKey", useCache=True)
-      result = client._queryAPI(
-        method, resourcePath, queryParams, postData=postData)
-    
-    expectedCacheString = hashlib.sha224(json.dumps([
-      resourcePath, method, json.dumps(queryParams), postData
-      ])).hexdigest()
-    expectedCachePath = "/tmp/cortipy/" + expectedCacheString + ".json"
-    
-    # Assert.
-    mockOpen.assert_called_once_with(expectedCachePath, "r")
-    self.assertEqual({"dummy": "mock body"}, result)
-  
-  
-  @httpretty.activate
-  @patch.object(os.path, 'exists', return_value=False)
-  def testNotUsingCache_ApiCallsDontReadFromCache(self, _mockExists):
-    """
-    When not using the cache, API calls that are already cached are not read 
-    from the cache instead.
-    """
-    # Arrange.
-    mockOpen = mock_open()
-    httpretty.register_uri(httpretty.GET,
-                           "http://api.cortical.io/rest/mockResourcePath",
-                           body='{"dummy":"mock body"}',
-                           status=200,
-                           content_type="application/json")
-    resourcePath = "/mockResourcePath"
-    method = "GET"
-    queryParams = "mock queryParams"
-    postData = "mock postData"
-  
-    client = cortipy.CorticalClient(apiKey="fakeKey", useCache=False)
-    client._queryAPI(method, resourcePath, queryParams, postData=postData)
-  
-    # Assert.
-    self.assertEqual(0, mockOpen.call_count,
-      "Caching was attempted when useCache=False.")
+
+    cacheDir = tempfile.mkdtemp()
+    self.addCleanup(shutil.rmtree, cacheDir)
+
+    # Act.  Make two identical calls.
+    client = cortipy.CorticalClient(apiKey="fakeKey",
+                                    useCache=True,
+                                    cacheDir=cacheDir)
+    result1 = client._queryAPI(
+      method, resourcePath, queryParams, postData=postData)
+    result2 = client._queryAPI(
+      method, resourcePath, queryParams, postData=postData)
+
+    # Assert.  Assert only one request made, both responses equal
+    self.assertEqual(mockGet.call_count, 1)
+    self.assertDictEqual(result1, result2)
 
 
 if __name__ == '__main__':

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -48,7 +48,7 @@ class CorticalClientTestCase(unittest.TestCase):
 
   def testWhenConstructingClientProperDefaultPropertiesAreSet(self):
     client = cortipy.CorticalClient(apiKey="fakeKey")
-    
+
     self.assertEqual(client.apiUrl, "http://api.cortical.io/rest",
       "Wrong default API URL")
     self.assertEqual(client.cacheDir, "/tmp/cortipy",
@@ -59,27 +59,28 @@ class CorticalClientTestCase(unittest.TestCase):
       "Wrong default retina")
     self.assertEqual(client.useCache, True,
       "Wrong default cache on/off setting")
-    
 
-  @patch.object(requests, "get")
+
+  @patch.object(requests.sessions.Session, "get")
   def testGetQueryToAPI(self, mockGet):
     """
     Tests the client can send a 'GET' query to the API, asserting we receive
     an HTTP status code reflecting successful operation.
     """
     # Arrange: patch the request in cortipy.CorticalClient._queryAPI().
-    # with patch.object(requests, 'get', return_value=) as mock_get:
+    # with patch.object(requests.sessions.Session,
+    #                   'get', return_value=) as mock_get:
     mockGet.return_value = Mock(
       content='{"dummy": "mock body"}', status_code=200)
     # Act:
     client = cortipy.CorticalClient(apiKey="fakeKey", useCache=False)
     response = client._queryAPI("GET", "/path", {})
-    
+
     # Assert:
     self.assertEqual({"dummy": "mock body"}, response)
-  
-  
-  @patch.object(requests, "post")
+
+
+  @patch.object(requests.sessions.Session, "post")
   def testPostQueryToAPI(self, mockPost):
     """
     Tests the client can send a 'POST' query to the API, asserting we receive
@@ -87,16 +88,16 @@ class CorticalClientTestCase(unittest.TestCase):
     """
     mockPost.return_value = Mock(
       content='{"dummy": "mock body"}', status_code=200)
-    
+
     # Act:
     client = cortipy.CorticalClient(apiKey="fakeKey")
     response = client._queryAPI("POST", "path", {})
-    
+
     # Assert:
     self.assertEqual({"dummy": "mock body"}, response)
-  
 
-  @patch.object(requests, "post")
+
+  @patch.object(requests.sessions.Session, "post")
   def testBadQueryMethodToAPI(self, mockPost):
     """
     Tests the client sending an invalid query method to the API, asserting we
@@ -104,7 +105,7 @@ class CorticalClientTestCase(unittest.TestCase):
     """
     mockPost.return_value = Mock(
       content='{"dummy": "mock body"}', status_code=None)
-    
+
     # Act:
     client = cortipy.CorticalClient(apiKey="fakeKey")
 
@@ -113,7 +114,7 @@ class CorticalClientTestCase(unittest.TestCase):
       client._queryAPI("BAD_METHOD", "path", {})
 
 
-  @patch.object(requests, "get")
+  @patch.object(requests.sessions.Session, "get")
   def testAPICannotEncodeError(self, mockPost):
     """
     Tests the client receiving an HTTP error code from the API, asserting we
@@ -121,10 +122,10 @@ class CorticalClientTestCase(unittest.TestCase):
     """
     mockPost.return_value = Mock(
       content='{"dummy": "mock body"}', status_code=400)
-    
+
     # Act:
     client = cortipy.CorticalClient(apiKey="fakeKey")
-    
+
     # Assert:
     with self.assertRaises(UnsuccessfulEncodingError):
       client._queryAPI("GET", "path", {})
@@ -134,7 +135,7 @@ class CorticalClientTestCase(unittest.TestCase):
   def testGetBitmap(self):
     """
     Tests client.getBitmap(). Asserts the proper query parameters are passed
-    to the API, returns a complete JSON string in response, and asserts that 
+    to the API, returns a complete JSON string in response, and asserts that
     string is converted into the expected result object for the client code.
     """
     # Arrange: mock JSON response from API, mock out the API endpoint we expect
@@ -143,12 +144,12 @@ class CorticalClientTestCase(unittest.TestCase):
     httpretty.register_uri(httpretty.GET, "http://api.cortical.io/rest/terms",
                            body=mockResponseString,
                            content_type="application/json")
-                           
+
     # Act: create the client object we'll be testing.
     client = cortipy.CorticalClient(
       apiKey="fakeKey", verbosity=0, useCache=False, retina="en_synonymous")
     bitmap = client.getBitmap("owl")
-  
+
     # Assert: check the result object.
     self.assertTrue("term" in bitmap,
       "No \'term\' field in the returned object.")
@@ -162,7 +163,7 @@ class CorticalClientTestCase(unittest.TestCase):
     self.assertIsInstance(bitmap["fingerprint"]["positions"], list,
       "The returned object does not contain a \'positions\' list within its "
       " \'fingerprint\' dictionary.")
-    
+
     # Assert: get the request sent to the API and check it.
     request = httpretty.last_request()
     self.assertEqual(request.method, 'GET', "Incorrect request method.")
@@ -176,13 +177,13 @@ class CorticalClientTestCase(unittest.TestCase):
                                         "max_results": ["10"],
                                         "get_fingerprint": ["True"]},
       "The request field \'queryString\' does not have the expected values.")
-  
-  
+
+
   @httpretty.activate
   def testGetTextBitmap(self):
     """
     Tests client.getTextBitmap(). Asserts the proper query parameters are passed
-    to the API, returns a complete JSON string in response, and asserts that 
+    to the API, returns a complete JSON string in response, and asserts that
     string is converted into the expected result object for the client code.
     """
     # Arrange: mock JSON response from API, mock out the API endpoint we expect
@@ -191,12 +192,12 @@ class CorticalClientTestCase(unittest.TestCase):
     httpretty.register_uri(httpretty.POST, "http://api.cortical.io/rest/text",
                            body=mockResponseString,
                            content_type="application/json")
-                           
+
     # Act: create the client object we'll be testing.
     client = cortipy.CorticalClient(
       apiKey="fakeKey", verbosity=0, useCache=False, retina="en_synonymous")
     bitmap = client.getTextBitmap("do androids dream of electric sheep")
-  
+
     # Assert: check the result object.
     self.assertTrue("text" in bitmap,
       "No \'text\' field in the returned object.")
@@ -208,7 +209,7 @@ class CorticalClientTestCase(unittest.TestCase):
     self.assertIsInstance(bitmap["fingerprint"]["positions"], list,
       "The returned object does not contain a \'positions\' list within its "
       " \'fingerprint\' dictionary.")
-    
+
     # Assert: get the request sent to the API and check it.
     request = httpretty.last_request()
     self.assertEqual(request.method, 'POST', "Incorrect request method.")
@@ -218,8 +219,8 @@ class CorticalClientTestCase(unittest.TestCase):
       "The request field \'queryString\' does not exist")
     self.assertEqual(request.querystring, {"retina_name": ["en_synonymous"]},
       "The request field \'queryString\' does not have the expected values.")
-  
-  
+
+
   @httpretty.activate
   def testCompareIdenticalFPs(self):
     """
@@ -235,12 +236,12 @@ class CorticalClientTestCase(unittest.TestCase):
                            content_type="application/json")
     fp1 = [0,13]
     fp2 = [0,13]
-  
+
     # Act: create the client object we'll be testing.
     client = cortipy.CorticalClient(
       apiKey="fakeKey", verbosity=0, useCache=False)
     distances = client.compare(fp1, fp2)
-    
+
     # Assert: expected distance metrics are returned, and result should reflect
     # minimum distances.
     self.assertTrue({"cosineSimilarity", "overlappingAll", "jaccardDistance",
@@ -254,8 +255,8 @@ class CorticalClientTestCase(unittest.TestCase):
     self.assertEqual(distances["overlappingAll"], 2,
       "Overlap count is incorrect. Expected 2 but received %d"
       % distances["overlappingAll"])
-  
-      
+
+
   @httpretty.activate
   def testCompareOrthogonalFPs(self):
     """
@@ -271,12 +272,12 @@ class CorticalClientTestCase(unittest.TestCase):
                            content_type="application/json")
     fp1 = [0]
     fp2 = [13]
-  
+
     # Act: create the client object we'll be testing.
     client = cortipy.CorticalClient(
       apiKey="fakeKey", verbosity=0, useCache=False)
     distances = client.compare(fp1, fp2)
-    
+
     # Assert: expected distance metrics are returned, and result should reflect
     # maximum distances.
     self.assertTrue({"cosineSimilarity", "overlappingAll", "jaccardDistance",
@@ -290,8 +291,8 @@ class CorticalClientTestCase(unittest.TestCase):
     self.assertEqual(distances["overlappingAll"], 0,
       "Overlap count is incorrect. Expected 0 but received %d"
       % distances["overlappingAll"])
-  
-  
+
+
   @httpretty.activate
   def testCompareSimilarFPs(self):
     """
@@ -310,18 +311,18 @@ class CorticalClientTestCase(unittest.TestCase):
     fp1 = [0,1]
     fp2 = [1,3]
     fp3 = [10,11]
-  
+
     # Act: create the client object we'll be testing.
     client = cortipy.CorticalClient(
       apiKey="fakeKey", verbosity=0, useCache=False)
     distances_similar = client.compare(fp1, fp2)
-    
+
     httpretty.register_uri(httpretty.POST,
                            "http://api.cortical.io/rest/compare",
                            body=mockResponseStringDissimilar,
                            content_type="application/json")
     distances_dissimilar = client.compare(fp1, fp3)
-    
+
     # Assert: result should reflect distances = 0.
     self.assertTrue((distances_similar["euclideanDistance"] <
             distances_dissimilar["euclideanDistance"]), ("Euclidean for "
@@ -345,12 +346,12 @@ class CorticalClientTestCase(unittest.TestCase):
                            "http://api.cortical.io/rest/terms/contexts",
                            body=mockResponseString,
                            content_type="application/json")
-    
+
     # Act: create the client object we'll be testing.
     client = cortipy.CorticalClient(
       apiKey="fakeKey", verbosity=0, useCache=False)
     contexts = client.getContext("android")
-    
+
     # Assert: check the result object.
     self.assertTrue(isinstance(contexts, list),
       "Returned object is not of type list as expected.")
@@ -361,7 +362,7 @@ class CorticalClientTestCase(unittest.TestCase):
       "The \'context_label\' field is not of type string.")
     self.assertEqual(contexts[0]["context_id"], 0,
       "The top context does not have ID of zero.")
-  
+
 
   @httpretty.activate
   def testCreateClassification(self):
@@ -373,11 +374,11 @@ class CorticalClientTestCase(unittest.TestCase):
     # to be called.
     mockResponseString = getMockApiData("dfw_category.json")
     httpretty.register_uri(
-      httpretty.POST, 
+      httpretty.POST,
       "http://api.cortical.io/rest/classify/create_category_filter",
       body=mockResponseString,
       content_type="application/json")
-                           
+
     # Act: create the client object we'll be testing.
     client = cortipy.CorticalClient(
       apiKey="fakeKey", verbosity=0, useCache=False, retina="en_synonymous")
@@ -394,7 +395,7 @@ class CorticalClientTestCase(unittest.TestCase):
       that some of its noisiest authorities insisted on its being received, \
       for good or for evil, in the superlative degree of comparison only."]
     response = client.createClassification("dfw", positives, negatives)
-  
+
     # Assert: check the result object.
     self.assertTrue("positions" in response,
       "No \'positions\' field in the returned object.")
@@ -405,7 +406,7 @@ class CorticalClientTestCase(unittest.TestCase):
       "The returned category name is incorrect.")
     self.assertIsInstance(response["positions"], list,
       "The returned object does not contain a \'positions\' list.")
-    
+
     # Assert: get the request sent to the API and check it.
     request = httpretty.last_request()
     self.assertEqual(request.method, 'POST', "Incorrect request method.")
@@ -417,7 +418,7 @@ class CorticalClientTestCase(unittest.TestCase):
                                            "filter_name": ["dfw"]},
       "The request field \'queryString\' does not have the expected values.")
 
-  
+
   def testGetSDRFromFingerprint(self):
     """
     Tests client.getSDR(). Asserts the correct binary string is returned for a
@@ -431,14 +432,14 @@ class CorticalClientTestCase(unittest.TestCase):
     # Act:
     client = cortipy.CorticalClient(apiKey="fakeKey")
     sdr = client.getSDR(fp)
-    
+
     # Assert:
     self.assertIsInstance(sdr, str, "Result is not of type string as expected.")
     self.assertEqual(sdr, '1000000000000100',
       "The resulting SDR does not match the input bitmap. Expected "
       "[1000000000000100] but instead received [%s]" % sdr)
-  
-  
+
+
   def testGetSDRFromNullFingerprint(self):
     """
     Tests client.getSDR(). Asserts the correct binary string is returned for an
@@ -452,7 +453,7 @@ class CorticalClientTestCase(unittest.TestCase):
     # Act:
     client = cortipy.CorticalClient(apiKey="fakeKey")
     sdr = client.getSDR(fp)
-    
+
     # Assert:
     self.assertIsInstance(sdr, str, "Result is not of type string as expected.")
     self.assertEqual(sdr, '0000000000000000',
@@ -468,16 +469,16 @@ class CorticalClientTestCase(unittest.TestCase):
     # Arrange:
     term1 = "Deckard"
     term2 = "Holden"
-    
+
     # Act:
     client = cortipy.CorticalClient(apiKey="fakeKey")
     fp1 = client._placeholderFingerprint(term1, option="random")
     fp2 = client._placeholderFingerprint(term2, option="random")
-  
+
     # Assert:
     self.assertNotEqual(fp1, fp2,
       "The generated bitmaps are identical, but should be different.")
-    
+
 
   def testForIdenticalPlaceholderFingerprints(self):
     """
@@ -486,12 +487,12 @@ class CorticalClientTestCase(unittest.TestCase):
     """
     # Arrange:
     term = "Rosen"
-    
+
     # Act:
     client = cortipy.CorticalClient(apiKey="fakeKey")
     fp1 = client._placeholderFingerprint(term, option="random")
     fp2 = client._placeholderFingerprint(term, option="random")
-  
+
     # Assert:
     self.assertEqual(fp1, fp2,
       "The generated bitmaps are different, but should be identical.")

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -86,6 +86,7 @@ class CorticalClientTestCase(unittest.TestCase):
     Tests the client can send a 'POST' query to the API, asserting we receive
     an HTTP status code reflecting successful operation.
     """
+    mockPost.__name__ = "post"
     mockPost.return_value = Mock(
       content='{"dummy": "mock body"}', status_code=200)
 
@@ -115,12 +116,13 @@ class CorticalClientTestCase(unittest.TestCase):
 
 
   @patch.object(requests.sessions.Session, "get")
-  def testAPICannotEncodeError(self, mockPost):
+  def testAPICannotEncodeError(self, mockGet):
     """
     Tests the client receiving an HTTP error code from the API, asserting we
     receive a UnsuccessfulEncodingError.
     """
-    mockPost.return_value = Mock(
+    mockGet.__name__ = "get"
+    mockGet.return_value = Mock(
       content='{"dummy": "mock body"}', status_code=400)
 
     # Act:


### PR DESCRIPTION
This is a superset of https://github.com/numenta/cortipy/pull/35 and introduces some speedups.
